### PR TITLE
feat: relax type constraints for ChatModel

### DIFF
--- a/src/langchain_graphrag/indexing/graph_generation/entity_relationship_extraction/extractor.py
+++ b/src/langchain_graphrag/indexing/graph_generation/entity_relationship_extraction/extractor.py
@@ -6,7 +6,7 @@ import logging
 
 import networkx as nx
 import pandas as pd
-from langchain_core.language_models import BaseLLM
+from langchain_core.language_models import LanguageModelLike
 from langchain_core.runnables.config import RunnableConfig
 from tqdm import tqdm
 
@@ -21,7 +21,7 @@ class EntityRelationshipExtractor:
     def __init__(
         self,
         prompt_builder: IndexingPromptBuilder,
-        llm: BaseLLM,
+        llm: LanguageModelLike,
         *,
         chain_config: RunnableConfig | None = None,
     ):
@@ -29,7 +29,7 @@ class EntityRelationshipExtractor:
 
         Args:
             prompt_builder (PromptBuilder): The prompt builder object used to construct the prompt for the language model.
-            llm (BaseLLM): The language model used for entity and relationship extraction.
+            llm (LanguageModelLike): The language model used for entity and relationship extraction.
             chain_config (RunnableConfig, optional): The configuration object for the extraction chain. Defaults to None.
 
         """
@@ -40,14 +40,14 @@ class EntityRelationshipExtractor:
 
     @staticmethod
     def build_default(
-        llm: BaseLLM,
+        llm: LanguageModelLike,
         *,
         chain_config: RunnableConfig | None = None,
     ) -> EntityRelationshipExtractor:
         """Builds and returns an instance of EntityRelationshipExtractor with default parameters.
 
         Parameters:
-            llm (BaseLLM): The BaseLLM object used for entity relationship extraction.
+            llm (LanguageModelLike): The language model used for entity relationship extraction.
             chain_config (RunnableConfig, optional): The configuration object for the extraction chain. Defaults to None.
 
         Returns:

--- a/src/langchain_graphrag/indexing/graph_generation/entity_relationship_summarization/summarizer.py
+++ b/src/langchain_graphrag/indexing/graph_generation/entity_relationship_summarization/summarizer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import networkx as nx
-from langchain_core.language_models import BaseLLM
+from langchain_core.language_models import LanguageModelLike
 from langchain_core.runnables.config import RunnableConfig
 from tqdm import tqdm
 
@@ -14,7 +14,7 @@ class EntityRelationshipDescriptionSummarizer:
     def __init__(
         self,
         prompt_builder: IndexingPromptBuilder,
-        llm: BaseLLM,
+        llm: LanguageModelLike,
         *,
         chain_config: RunnableConfig | None = None,
     ):
@@ -25,7 +25,7 @@ class EntityRelationshipDescriptionSummarizer:
 
     @staticmethod
     def build_default(
-        llm: BaseLLM,
+        llm: LanguageModelLike,
         *,
         chain_config: RunnableConfig | None = None,
     ) -> EntityRelationshipDescriptionSummarizer:

--- a/src/langchain_graphrag/indexing/report_generation/generator.py
+++ b/src/langchain_graphrag/indexing/report_generation/generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import networkx as nx
-from langchain_core.language_models import BaseLLM
+from langchain_core.language_models import LanguageModelLike
 from langchain_core.runnables.config import RunnableConfig
 
 from langchain_graphrag.types.graphs.community import Community
@@ -15,7 +15,7 @@ class CommunityReportGenerator:
     def __init__(
         self,
         prompt_builder: IndexingPromptBuilder,
-        llm: BaseLLM,
+        llm: LanguageModelLike,
         *,
         chain_config: RunnableConfig | None = None,
     ):
@@ -26,7 +26,7 @@ class CommunityReportGenerator:
 
     @staticmethod
     def build_default(
-        llm: BaseLLM,
+        llm: LanguageModelLike,
         *,
         chain_config: RunnableConfig | None = None,
     ) -> CommunityReportGenerator:

--- a/src/langchain_graphrag/query/global_search/key_points_aggregator/aggregator.py
+++ b/src/langchain_graphrag/query/global_search/key_points_aggregator/aggregator.py
@@ -2,7 +2,7 @@ import operator
 from functools import partial
 
 from langchain_core.documents import Document
-from langchain_core.language_models import BaseLLM
+from langchain_core.language_models import LanguageModelLike
 from langchain_core.runnables import Runnable, RunnableLambda
 
 from langchain_graphrag.query.global_search.key_points_generator.utils import (
@@ -29,7 +29,7 @@ def _kp_result_to_docs(
 class KeyPointsAggregator:
     def __init__(
         self,
-        llm: BaseLLM,
+        llm: LanguageModelLike,
         prompt_builder: PromptBuilder,
         context_builder: KeyPointsContextBuilder,
         *,

--- a/src/langchain_graphrag/query/global_search/key_points_generator/generator.py
+++ b/src/langchain_graphrag/query/global_search/key_points_generator/generator.py
@@ -1,5 +1,5 @@
 from langchain_core.documents import Document
-from langchain_core.language_models import BaseLLM
+from langchain_core.language_models import LanguageModelLike
 from langchain_core.runnables import Runnable, RunnableParallel
 
 from langchain_graphrag.types.prompts import PromptBuilder
@@ -16,7 +16,7 @@ def _format_docs(documents: list[Document]) -> str:
 class KeyPointsGenerator:
     def __init__(
         self,
-        llm: BaseLLM,
+        llm: LanguageModelLike,
         prompt_builder: PromptBuilder,
         context_builder: CommunityReportContextBuilder,
     ):

--- a/src/langchain_graphrag/query/local_search/search.py
+++ b/src/langchain_graphrag/query/local_search/search.py
@@ -1,5 +1,5 @@
 from langchain_core.documents import Document
-from langchain_core.language_models import BaseLLM
+from langchain_core.language_models import LanguageModelLike
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import Runnable, RunnablePassthrough
 
@@ -15,7 +15,7 @@ def _format_docs(documents: list[Document]) -> str:
 class LocalSearch:
     def __init__(
         self,
-        llm: BaseLLM,
+        llm: LanguageModelLike,
         prompt_builder: PromptBuilder,
         retriever: BaseRetriever,
         *,


### PR DESCRIPTION
Change type constraints to LanguageModelLike, allowing the use of ChatModel and similar chains. This change is particularly relevant as most current instruction models come with specific conversational formatting templates.

This change means llm object can return both str and BaseMessage classes. But the implementation of BaseOutputParser in langchain_core already accommodates these type differences.

Since this update only involves type annotations, it should not disrupt any existing use cases.

