### PR TITLE
fix(devcontainer): compatibility with Debian trixie

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,9 +69,11 @@
         // Rust (required by few python libraries)
         "ghcr.io/devcontainers/features/rust:1": {},
         // Enable Docker (via Docker-in-Docker)
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "moby": false
+        },
         // Modern shell utils
-        "ghcr.io/mikaello/devcontainer-features/modern-shell-utils:1": {},
+        "ghcr.io/mikaello/devcontainer-features/modern-shell-utils:2": {},
         // uv (Python package manager)
         "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {}
     },


### PR DESCRIPTION
 - docker-in-docker: set moby: false — moby-cli was removed from Debian trixie
  - modern-shell-utils: upgrade :1 → :2 — v1 installs exa which is replaced by eza in trixie